### PR TITLE
Added non structured response support in do_query

### DIFF
--- a/lib/quickbase.rb
+++ b/lib/quickbase.rb
@@ -70,7 +70,7 @@ module AdvantageQuickbase
 
     def do_query( db_id, options )
       # Define the query format
-      if !options[ :fmt ]
+      if options.has_key? :fmt
         options[ :fmt ] = 'structured'
       end
 
@@ -88,8 +88,14 @@ module AdvantageQuickbase
       return_json = []
       result.css( 'record' ).each do |record|
         json_record = {}
-        record.css( 'f' ).each do |field|
-          json_record[ field['id'] ] = field.text
+        if options.has_key? :fmt
+          record.css( 'f' ).each do |field|
+            json_record[ field['id'] ] = field.text
+          end
+        else
+          record.element_children.each do |field|
+            json_record[ field.node_name ] = field.text
+          end
         end
 
         return_json << json_record

--- a/lib/quickbase.rb
+++ b/lib/quickbase.rb
@@ -70,7 +70,9 @@ module AdvantageQuickbase
 
     def do_query( db_id, options )
       # Define the query format
-      if options.has_key? :fmt
+      if options.has_key?( :fmt ) && options[:fmt].blank?
+        options.delete :fmt
+      else
         options[ :fmt ] = 'structured'
       end
 


### PR DESCRIPTION
do_query always returned the structured response..

I have modified the do_query method, so that if :fmt is not provided in parameters, then non-structured response will be returned. Column names will be used as keys.

Please note that quickbase API converts special characters and space in column names with '_', and this method will return it as is.
