### PR TITLE
Fixed do_query method when called without fmt paramater

### DIFF
--- a/lib/quickbase.rb
+++ b/lib/quickbase.rb
@@ -90,22 +90,21 @@ module AdvantageQuickbase
       return_json = []
       result.css( 'record' ).each do |record|
         json_record = {}
-
-        record.css( 'f' ).each do |field|
-          if options.has_key? :fmt
-            # File attachment fields shuold return a hash with keys :filename and :url
+        
+        if options.has_key? :fmt
+          record.css( 'f' ).each do |field|
+            # File attachment fields should return a hash with keys :filename and :url
             if !field.css("url").text.empty?
               fieldname = Nokogiri::XML.parse(field.to_html.gsub(/<url.*?<\/url>/, "")).text
               value = { filename: fieldname, url: field.css("url").text }
             else
               value = field.text
             end
-
             json_record[ field['id'] ] = value
-          else
-            record.element_children.each do |field|
-              json_record[ field.node_name ] = value
-            end
+          end
+        else
+          record.element_children.each do |field|
+            json_record[ field.node_name ] = value
           end
         end
 

--- a/lib/quickbase.rb
+++ b/lib/quickbase.rb
@@ -104,7 +104,7 @@ module AdvantageQuickbase
           end
         else
           record.element_children.each do |field|
-            json_record[ field.node_name ] = value
+            json_record[ field.node_name ] = field.text
           end
         end
 


### PR DESCRIPTION
`record.css('f')` is used to loop over the fields returned in the do_query with fmt parameter.
`record.element_children` is used to loop over the fields returned in do_query without fmt parameter.

the if condition
`if options.has_key :fmt`
should be stated before looping over the fields, so to know if `record.css('f')` should be used or `record.element_children`
