### PR TITLE
Raise exception if the HTTP request fail

### DIFF
--- a/lib/quickbase.rb
+++ b/lib/quickbase.rb
@@ -414,7 +414,8 @@ module AdvantageQuickbase
       url = build_request_url( api_call, db_id )
       headers = build_request_headers( api_call, request_xml )
       result = @http.post( url, request_xml, headers )
-			puts result
+      # Raise Net::HTTPServerException if HTTP code is not 200
+      result.value
 
       xml_result = parse_xml( result.body )
 


### PR DESCRIPTION
If a request to Quickbase API fails with HTTP status code other than 200, the send_request method returns the xml of returned error page (404 or 500 pages etc).
It should have raised an exception in this case.
I have called `result.value` right after the request so that it would raise Net::HTTPServerException if HTTP status code is not 200.
