### PR TITLE
Fix Syntax Error and Add AppVars to get_schema

### DIFF
--- a/lib/quickbase.rb
+++ b/lib/quickbase.rb
@@ -221,6 +221,14 @@ module AdvantageQuickbase
 
           schema_hash[ :tables ][ table_hash[:dbid] ] = table_hash
         end
+
+        # Add Application Variables
+        schema_hash[ :variables ] = {}
+        vars = result.css( 'var' )
+        vars.each do |var|
+          name = var.attributes['name'].to_s
+          schema_hash[ :variables ][name] = var.text
+        end
       else
         # Table mode
         schema_hash[ :mode ] = 'table'
@@ -335,8 +343,7 @@ module AdvantageQuickbase
       new_values = new_values.map do |field_id, value|
         # Values that are hashes with name and file are encoded seperately
         if value.is_a?( Hash ) && value.length == 2 && value[:name] && value[:file]
-          file = !value[:bypass_encoding] ? encode_file( value[:file] ) || value[:file]
-
+          file = !value[:bypass_encoding] ? encode_file( value[:file] ) : value[:file]
           "<field fid='#{field_id}' filename='#{value[:name]}'>#{file}</field>"
         else
           "<field fid='#{field_id}'>#{value.to_s.encode(xml: :text)}</field>"


### PR DESCRIPTION
@KitHensel, CC: @liquidise @zsiglin 

It looks like commit af4a56d937f8591c719b804eae35be05d702aa29 introduced a syntax error in the QuickBase gem. This could potentially break many of your gem users out there.

Also, our app has a lot of application vars so calling `get_db_var` for each is rather inefficient when we can just use `get_schema` to grab them all at once.

This PR fixes the syntax error and adds appvars to the get_schema response.

Current `get_schema` response:
```ruby
{
 :app_id=>"example_table_id",
 :table_id=>"example_table_id",
 :name=>"My Example App",
 :mode=>"app",
 :tables=> {"dbid"=>{:dbid=>"example", :name=>"Applications"}}
}
```

New `get_schema` response:
```ruby
{
 :app_id=>"example_table_id",
 :table_id=>"example_table_id",
 :name=>"My Example App",
 :mode=>"app",
 :tables=> {"dbid"=>{:dbid=>"example", :name=>"Applications"}},
 :variables => {
    "EXAMPLE_VAR_1" => "some_value",
    "EXAMPLE_VAR_2" => "some_value"
 }
}
```

Any ETA on when we might be able to get this merged? Thanks in advance!